### PR TITLE
feat: Update positioning to 'Notes That Level You Up'

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,17 +8,16 @@ const inter = Inter({
 });
 
 export const metadata: Metadata = {
-  title: "Avanço - Transform Your BJJ Training Notes Into Actionable Insights",
+  title: "Avanço - Notes That Level You Up",
   description:
-    "AI-powered note enhancement that turns raw training observations into structured, searchable knowledge for Brazilian Jiu-Jitsu practitioners.",
+    "Your complete BJJ training companion. AI-enhanced notes, smart flashcards, personalized training plans, and progress tracking. Everything you need to master Brazilian Jiu-Jitsu, faster.",
   keywords:
-    "BJJ, Brazilian Jiu-Jitsu, training notes, AI notes, martial arts, grappling, training journal",
+    "BJJ, Brazilian Jiu-Jitsu, training notes, AI notes, martial arts, grappling, training journal, flashcards, training plan, BJJ stats",
   authors: [{ name: "Avanço" }],
   openGraph: {
-    title:
-      "Avanço - Transform Your BJJ Training Notes Into Actionable Insights",
+    title: "Avanço - Notes That Level You Up",
     description:
-      "AI-powered note enhancement that turns raw training observations into structured, searchable knowledge.",
+      "AI-enhanced notes, smart flashcards, personalized training plans, and progress tracking for BJJ practitioners.",
     url: "https://avanco.app",
     siteName: "Avanço",
     images: [
@@ -33,9 +32,9 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: "summary_large_image",
-    title: "Avanço - Transform Your BJJ Training Notes",
+    title: "Avanço - Notes That Level You Up",
     description:
-      "AI-powered note enhancement for Brazilian Jiu-Jitsu practitioners",
+      "Your complete BJJ training companion with AI-enhanced notes, flashcards, and training plans",
     images: ["/og-image.png"],
   },
 };

--- a/src/components/faq.tsx
+++ b/src/components/faq.tsx
@@ -13,12 +13,12 @@ const faqItems: FAQItem[] = [
   {
     question: "What exactly is Avanço and how does it work?",
     answer:
-      "Avanço is an AI-powered training journal for Brazilian Jiu-Jitsu practitioners. Simply record voice notes or type rough notes after training, and our AI automatically structures them, identifies techniques and patterns, creates connections between sessions, and makes everything instantly searchable. It's like having a personal BJJ data analyst that transforms messy notes into actionable insights.",
+      "Avanço is your complete BJJ training companion that helps you level up faster. Start by recording voice or text notes after training - our AI automatically structures them, identifies techniques, and creates connections. Then, use smart flashcards for spaced repetition, follow personalized training plans tailored to your goals, track your progress with detailed stats, and engage with gamified drills. It's an all-in-one system designed specifically for BJJ practitioners to accelerate mastery.",
   },
   {
     question: "How is this different from regular note-taking apps?",
     answer:
-      "Unlike generic note apps, Avanço understands BJJ context. It automatically recognizes techniques, positions, and submissions, tracks your progress with specific training partners, identifies patterns in your game, and provides AI-generated insights. Every note becomes part of your searchable BJJ knowledge base, helping you identify weaknesses and accelerate improvement.",
+      "Avanço is a complete training system, not just a note-taking app. While it starts with AI-enhanced notes that understand BJJ context, it goes much further: auto-generated flashcards for technique retention, personalized training plans based on your progress, detailed analytics and stats, ecological games for skill development, and session reviews with AI insights. Everything is connected and designed specifically for martial arts learning.",
   },
   {
     question: "Is my training data private and secure?",
@@ -38,17 +38,17 @@ const faqItems: FAQItem[] = [
   {
     question: "Can I record voice notes directly in the app?",
     answer:
-      "Yes! Just tap the microphone button and speak naturally about your training - who you rolled with, what worked, what didn't. Avanço instantly transcribes your voice notes and enhances them with AI processing. It's perfect for capturing thoughts immediately after rolling when details are fresh in your mind.",
+      "Yes! Just tap the microphone button and speak naturally about your training - who you rolled with, what worked, what didn't. Avanço instantly transcribes and enhances your voice notes with AI, then automatically generates flashcards from key techniques and updates your training stats. It's the fastest way to capture insights right after rolling when details are fresh.",
   },
   {
     question: "Does it work for both beginners and advanced practitioners?",
     answer:
-      "Absolutely! Whether you're a white belt learning fundamentals or a black belt refining details, Avanço adapts to your level. Beginners benefit from structured learning and pattern recognition, while advanced practitioners can track subtle adjustments and competition preparation. The AI insights grow more personalized as it learns your training style.",
+      "Absolutely! Whether you're a white belt or a black belt, Avanço adapts to your level. Beginners benefit from structured training plans, flashcard reviews of fundamentals, and clear progress tracking. Advanced practitioners can refine subtle details, prepare for competitions, and use ecological games to maintain technique retention. The entire system becomes more personalized as it learns your training style and goals.",
   },
   {
     question: "Can I share my notes with my coach or training partners?",
     answer:
-      "Yes, you have complete control over sharing. You can selectively share specific training entries or technique notes with your coach or training partners. This is perfect for getting feedback on your progress or coordinating training focus with partners. You always maintain control over what you share and with whom.",
+      "Yes, you have complete control over sharing. You can selectively share training notes, progress stats, or training plan goals with your coach or training partners. This is perfect for getting feedback, coordinating training focus, or showing your competition preparation progress. You always maintain control over what you share and with whom.",
   },
 ];
 

--- a/src/components/features.tsx
+++ b/src/components/features.tsx
@@ -1,44 +1,53 @@
 "use client";
 
 import { motion } from "framer-motion";
-import { BookOpen, Brain, Mic, Search, Target, TrendingUp } from "lucide-react";
+import {
+  BookOpen,
+  Brain,
+  Gamepad2,
+  Layers,
+  Mic,
+  Route,
+  Search,
+  TrendingUp,
+} from "lucide-react";
 
 const features = [
   {
     icon: <Brain className="w-6 h-6" />,
-    title: "Smart Enhancement",
+    title: "AI-Enhanced Notes",
     description:
-      "AI automatically structures your notes, identifies techniques, and creates connections between training sessions.",
+      "Voice or text notes automatically structured and enhanced. Captures techniques, insights, and connections from every session.",
   },
   {
-    icon: <Search className="w-6 h-6" />,
-    title: "Instant Search",
+    icon: <Layers className="w-6 h-6" />,
+    title: "Smart Flashcards",
     description:
-      "Find that specific guard pass from three months ago in seconds. Search by technique, partner, or concept.",
+      "Auto-generated flashcards from your notes. Review techniques, positions, and concepts with spaced repetition.",
+  },
+  {
+    icon: <Route className="w-6 h-6" />,
+    title: "Training Plans",
+    description:
+      "Personalized training roadmaps based on your goals, gaps, and progress. Know exactly what to focus on next.",
   },
   {
     icon: <TrendingUp className="w-6 h-6" />,
-    title: "Progress Tracking",
+    title: "Progress Analytics",
     description:
-      "Visualize your improvement over time. See which techniques you're mastering and where to focus next.",
+      "Visualize your growth with detailed stats. Track techniques mastered, mat time, and improvement trends.",
   },
   {
-    icon: <Mic className="w-6 h-6" />,
-    title: "Voice Notes",
+    icon: <Gamepad2 className="w-6 h-6" />,
+    title: "Interactive Drills",
     description:
-      "Record thoughts immediately after training. Avanço transcribes and enhances them automatically.",
-  },
-  {
-    icon: <Target className="w-6 h-6" />,
-    title: "Pattern Recognition",
-    description:
-      "Discover recurring challenges and breakthrough moments across your training history.",
+      "Gamified learning experiences and ecological drills. Make technique retention fun and effective.",
   },
   {
     icon: <BookOpen className="w-6 h-6" />,
-    title: "Knowledge Base",
+    title: "Session Reviews",
     description:
-      "Build your personal BJJ encyclopedia with cross-referenced techniques and concepts.",
+      "Revisit past training with AI-powered insights. See patterns, breakthroughs, and areas for improvement.",
   },
 ];
 
@@ -54,11 +63,11 @@ export function FeaturesSection() {
           className="text-center mb-16"
         >
           <h2 className="text-4xl lg:text-5xl font-bold mb-4 text-gray-900">
-            Capture Everything, Miss Nothing
+            Everything You Need to Level Up
           </h2>
           <p className="text-xl text-gray-600 max-w-2xl mx-auto">
-            Whether you're drilling techniques or sparring, Avanço ensures every
-            insight is preserved and enhanced.
+            From intelligent note-taking to personalized training plans, Avanço
+            gives you the complete toolkit for BJJ mastery.
           </p>
         </motion.div>
 

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -36,7 +36,7 @@ export function HeroSection() {
         >
           <motion.div variants={fadeIn} className="mb-6">
             <span className="inline-block px-4 py-1 bg-gradient-to-r from-orange-200 to-rose-200 text-orange-800 rounded-full text-sm font-medium">
-              AI-Powered BJJ Training Journal
+              Your Complete BJJ Training Companion
             </span>
           </motion.div>
 
@@ -44,9 +44,8 @@ export function HeroSection() {
             variants={fadeIn}
             className="text-5xl lg:text-7xl font-bold mb-6 text-gray-900"
           >
-            Transform Your BJJ Training Notes Into{" "}
             <span className="bg-gradient-to-r from-orange-500 to-rose-500 bg-clip-text text-transparent">
-              Actionable Insights
+              Notes That Level You Up
             </span>
           </motion.h1>
 
@@ -54,9 +53,9 @@ export function HeroSection() {
             variants={fadeIn}
             className="text-xl text-gray-600 mb-10 max-w-2xl mx-auto"
           >
-            Turn voice memos, rough notes, and training observations into
-            structured, searchable knowledge that accelerates your Brazilian
-            Jiu-Jitsu journey.
+            AI-enhanced notes, smart flashcards, personalized training plans,
+            and progress tracking. Everything you need to master Brazilian
+            Jiu-Jitsu, faster.
           </motion.p>
 
           <motion.div

--- a/src/components/how-it-works.tsx
+++ b/src/components/how-it-works.tsx
@@ -20,9 +20,9 @@ const steps = [
   },
   {
     number: "3",
-    title: "Review & Improve",
+    title: "Train & Level Up",
     description:
-      "Search past sessions, identify patterns, and accelerate your learning curve.",
+      "Use flashcards, follow personalized training plans, track stats, and master techniques faster.",
     icon: <TrendingUp className="w-6 h-6" />,
   },
 ];

--- a/src/components/roadmap.tsx
+++ b/src/components/roadmap.tsx
@@ -1,20 +1,35 @@
 "use client";
 
 import { motion } from "framer-motion";
-import { Brain, Calendar, Target, Trophy, Users, Zap } from "lucide-react";
+import {
+  Brain,
+  Calendar,
+  Gamepad2,
+  Target,
+  Trophy,
+  Users,
+  Zap,
+} from "lucide-react";
 
 const roadmapItems = [
   {
     icon: <Zap className="w-6 h-6" />,
     title: "Smart Flashcards",
-    status: "Q1 2026",
+    status: "Coming Soon",
     description: "Review techniques with spaced repetition and visual aids.",
   },
   {
     icon: <Calendar className="w-6 h-6" />,
     title: "Training Plans",
-    status: "Q1 2026",
+    status: "Coming Soon",
     description: "AI-generated weekly plans based on your progress and goals.",
+  },
+  {
+    icon: <Gamepad2 className="w-6 h-6" />,
+    title: "Gamified Drills",
+    status: "Q1 2026",
+    description:
+      "Interactive games and ecological drills that make learning techniques fun and memorable.",
   },
   {
     icon: <Users className="w-6 h-6" />,
@@ -27,13 +42,6 @@ const roadmapItems = [
     title: "Competition Prep",
     status: "Q2 2026",
     description: "Tournament-specific game plans and mental preparation tools.",
-  },
-  {
-    icon: <Target className="w-6 h-6" />,
-    title: "Ecological Training",
-    status: "Q2 2026",
-    description:
-      "Adaptive training recommendations based on your learning style.",
   },
   {
     icon: <Brain className="w-6 h-6" />,


### PR DESCRIPTION
## Summary
- Updated hero tagline to "Notes That Level You Up" to better reflect the complete training system
- Repositioned Avanço from a note-taking app to a complete BJJ training companion
- Updated all marketing copy to emphasize future features: flashcards, training plans, analytics, and gamified drills

## Changes
- **Hero section**: New tagline and description highlighting complete feature set
- **Features section**: Rewritten 6 features showcasing notes, flashcards, training plans, analytics, drills, and session reviews
- **How It Works**: Updated step 3 to "Train & Level Up" with mention of flashcards and training plans
- **Roadmap**: Added gamified drills, marked flashcards/training plans as "Coming Soon"
- **FAQs**: Updated to reflect positioning as complete training system (not just notes)
- **Metadata**: Updated page title, descriptions, and social media tags for SEO

## Test plan
- [ ] Review landing page locally
- [ ] Verify all new copy aligns with "level up" positioning
- [ ] Check FAQs accurately describe future features
- [ ] Confirm metadata updates appear correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)