### PR TITLE
feat: Integrate Tally form for waitlist signup

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import { GoogleAnalytics } from "@next/third-parties/google";
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
+import Script from "next/script";
 import "./globals.css";
 
 const inter = Inter({
@@ -52,6 +53,7 @@ export default function RootLayout({
       >
         {children}
       </body>
+      <Script src="https://tally.so/widgets/embed.js" strategy="lazyOnload" />
       <GoogleAnalytics gaId="G-5XDM3P5VV9" />
     </html>
   );

--- a/src/components/cta.tsx
+++ b/src/components/cta.tsx
@@ -1,11 +1,8 @@
 "use client";
 
 import { motion } from "framer-motion";
-import { useState } from "react";
 
 export function CTASection() {
-  const [email, setEmail] = useState("");
-
   return (
     <section className="py-20 lg:py-32 relative overflow-hidden">
       <div className="absolute inset-0 bg-gradient-to-br from-orange-500 to-rose-500" />
@@ -23,29 +20,20 @@ export function CTASection() {
             Join the waitlist and be the first to transform your training with
             Avanço.
           </p>
-          <form
-            onSubmit={(e) => {
-              e.preventDefault();
-              console.log("Email submitted:", email);
-              setEmail("");
-            }}
-            className="flex flex-col sm:flex-row gap-4 max-w-md mx-auto"
-          >
-            <input
-              type="email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              placeholder="Enter your email"
-              required
-              className="flex-1 px-4 py-3 rounded-full bg-white/20 backdrop-blur-lg text-white placeholder-orange-100 border border-white/30 focus:outline-none focus:border-white/50"
-            />
+          <div className="flex flex-col sm:flex-row gap-4 max-w-md mx-auto justify-center">
             <button
-              type="submit"
-              className="px-6 py-3 bg-white text-orange-600 rounded-full font-semibold hover:bg-orange-50 transition-all hover:scale-105"
+              type="button"
+              className="px-8 py-4 bg-white text-orange-600 rounded-full font-semibold hover:bg-orange-50 transition-all hover:scale-105"
+              data-tally-open="wkMzN6"
+              data-tally-align-left="1"
+              data-tally-emoji-text="👋"
+              data-tally-emoji-animation="wave"
+              data-tally-auto-close="7000"
+              data-tally-form-events-forwarding="1"
             >
               Join Waitlist
             </button>
-          </form>
+          </div>
           <p className="mt-4 text-sm text-orange-100">
             No credit card required • Early access • Exclusive updates
           </p>

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -50,6 +50,12 @@ export function Header() {
             <button
               type="button"
               className="px-4 py-2 bg-gradient-to-r from-orange-400 to-rose-400 text-white rounded-full hover:shadow-lg transition-all hover:scale-105"
+              data-tally-open="wkMzN6"
+              data-tally-align-left="1"
+              data-tally-emoji-text="👋"
+              data-tally-emoji-animation="wave"
+              data-tally-auto-close="7000"
+              data-tally-form-events-forwarding="1"
             >
               Join Waitlist
             </button>
@@ -88,6 +94,12 @@ export function Header() {
               <button
                 type="button"
                 className="px-4 py-2 bg-gradient-to-r from-orange-400 to-rose-400 text-white rounded-full"
+                data-tally-open="wkMzN6"
+                data-tally-align-left="1"
+                data-tally-emoji-text="👋"
+                data-tally-emoji-animation="wave"
+                data-tally-auto-close="7000"
+                data-tally-form-events-forwarding="1"
               >
                 Join Waitlist
               </button>


### PR DESCRIPTION
## Summary
- Added Tally embed script using next/script in the root layout
- Updated all "Join Waitlist" buttons (header desktop, header mobile, and CTA section) with Tally data attributes to trigger the popup form
- Replaced the email input form in the CTA section with a Tally popup button for a cleaner UX
- Configured Tally popup with emoji animation (👋 wave) and auto-close after 7 seconds

## Test plan
- [ ] Click "Join Waitlist" button in the header (desktop view)
- [ ] Click "Join Waitlist" button in the mobile menu
- [ ] Click "Join Waitlist" button in the CTA section
- [ ] Verify that the Tally form popup appears with the emoji animation
- [ ] Verify that the form auto-closes after 7 seconds
- [ ] Test form submission

🤖 Generated with [Claude Code](https://claude.com/claude-code)